### PR TITLE
Features/restore train mode

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -135,6 +135,10 @@ function process_tick()
 					global.wagon_data[player_index] = nil
 					return player.print({"generic-error"})
 				end
+				if wagon.train.speed > 0 then
+					global.wagon_data[player_index] = nil
+					return player.print({"train-in-motion-error"})
+				end
 				local trainInManual = wagon.train.valid and wagon.train.manual_mode or false
 				wagon.destroy()
 				local loaded_wagon = player.surface.create_entity({name = global.wagon_data[player_index].name, position = position, force = player.force})
@@ -176,6 +180,10 @@ function process_tick()
 				if not loaded_wagon.valid then
 					global.wagon_data[player_index] = nil
 					return player.print({"generic-error"})
+				end
+				if loaded_wagon.train.speed > 0 then
+					global.wagon_data[player_index] = nil
+					return player.print({"train-in-motion-error"})
 				end
 				local wagon_position = loaded_wagon.position
 				local trainInManual = loaded_wagon.train.valid and loaded_wagon.train.manual_mode or false
@@ -228,6 +236,9 @@ function unloadWagon(loaded_wagon, player)
 	if loaded_wagon.get_driver() then
 		return player.print({"passenger-error"})
 	end
+	if loaded_wagon.train.speed > 0 then
+		return player.print({"train-in-motion-error"})
+	end
 	player.set_gui_arrow({type = "entity", entity = loaded_wagon})
 	playSoundForPlayer("winch-sound", player)
 	global.wagon_data[player.index] = {}
@@ -255,6 +266,9 @@ function handleWagon(wagon, player_index)
 	local player = game.players[player_index]
 	if wagon.get_driver() then
 		return player.print({"passenger-error"})
+	end
+	if wagon.train.speed > 0 then
+		return player.print({"train-in-motion-error"})
 	end
 	if global.vehicle_data[player_index] then
 		local vehicle = global.vehicle_data[player_index]

--- a/control.lua
+++ b/control.lua
@@ -135,7 +135,7 @@ function process_tick()
 					global.wagon_data[player_index] = nil
 					return player.print({"generic-error"})
 				end
-				if wagon.train.speed > 0 then
+				if wagon.train.speed ~= 0 then
 					global.wagon_data[player_index] = nil
 					return player.print({"train-in-motion-error"})
 				end
@@ -236,7 +236,7 @@ function unloadWagon(loaded_wagon, player)
 	if loaded_wagon.get_driver() then
 		return player.print({"passenger-error"})
 	end
-	if loaded_wagon.train.speed > 0 then
+	if loaded_wagon.train.speed ~= 0 then
 		return player.print({"train-in-motion-error"})
 	end
 	player.set_gui_arrow({type = "entity", entity = loaded_wagon})
@@ -267,7 +267,7 @@ function handleWagon(wagon, player_index)
 	if wagon.get_driver() then
 		return player.print({"passenger-error"})
 	end
-	if wagon.train.speed > 0 then
+	if wagon.train.speed ~= 0 then
 		return player.print({"train-in-motion-error"})
 	end
 	if global.vehicle_data[player_index] then

--- a/control.lua
+++ b/control.lua
@@ -135,6 +135,7 @@ function process_tick()
 					global.wagon_data[player_index] = nil
 					return player.print({"generic-error"})
 				end
+				local trainInManual = wagon.train.valid and wagon.train.manual_mode or false
 				wagon.destroy()
 				local loaded_wagon = player.surface.create_entity({name = global.wagon_data[player_index].name, position = position, force = player.force})
 				loaded_wagon.health = wagon_health
@@ -163,6 +164,7 @@ function process_tick()
 				end
 				vehicle.destroy()
 				global.wagon_data[player_index] = nil
+				loaded_wagon.train.manual_mode = trainInManual
 			elseif global.wagon_data[player_index].status == "unload" and global.wagon_data[player_index].tick == current_tick then
 				local loaded_wagon = global.wagon_data[player_index].wagon
 				local wagon_health = loaded_wagon.health
@@ -176,6 +178,7 @@ function process_tick()
 					return player.print({"generic-error"})
 				end
 				local wagon_position = loaded_wagon.position
+				local trainInManual = loaded_wagon.train.valid and loaded_wagon.train.manual_mode or false
 				local unload_position = player.surface.find_non_colliding_position(global.wagon_data[loaded_wagon.unit_number].name, wagon_position, 5, 1)
 				if not unload_position then
 					global.wagon_data[player_index] = nil
@@ -199,6 +202,7 @@ function process_tick()
 				loaded_wagon.destroy()
 				local wagon = player.surface.create_entity({name = "vehicle-wagon", position = wagon_position, force = player.force})
 				wagon.health = wagon_health
+				wagon.train.manual_mode = trainInManual
 				global.wagon_data[player_index] = nil
 			end
 		end

--- a/control.lua
+++ b/control.lua
@@ -181,7 +181,7 @@ function process_tick()
 					global.wagon_data[player_index] = nil
 					return player.print({"generic-error"})
 				end
-				if loaded_wagon.train.speed > 0 then
+				if loaded_wagon.train.speed ~= 0 then
 					global.wagon_data[player_index] = nil
 					return player.print({"train-in-motion-error"})
 				end

--- a/locale/de/de.cfg
+++ b/locale/de/de.cfg
@@ -3,6 +3,7 @@ passenger-error=Error: Fahrzeuge mit Passagieren können nicht aufgeladen werden
 position-error=Error: Konnte keinen passenden Ort zum Entladen des Fahrzeugs finden.
 unknown-vehicle-error=Error: Das ausgewählte Fahrzeug wird nicht unterstützt.
 too-far-away=Error: Das ausgewählte Fahrzeug ist zu weit entfernt von Waggon.
+train-in-motion-error=Error: Züge können nicht in bewegung geladen / entladen werden
 vehicle-selected=Fahrzeug ausgewählt! Bitte wähle nun einen sich in der Nähe befindlichen Fahrzeugtransporter.
 no-vehicle-selected=Kein Fahrzeug ausgewählt.
 item-inserted=+__1__ __2__

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -3,6 +3,7 @@ passenger-error=Error: Cannot winch vehicles that currently have a passenger.
 position-error=Error: Unable to find a location to unload the vehicle.
 unknown-vehicle-error=Error: The selected vehicle is not supported.
 too-far-away=Error: The chosen wagon is too far away from the selected vehicle.
+train-in-motion-error=Error: Trains cannot be loaded/unloaded when in motion
 vehicle-selected=Vehicle selected! Now click a nearby Vehicle Wagon.
 no-vehicle-selected=No vehicle selected.
 item-inserted=+__1__ __2__


### PR DESCRIPTION
- Fixes probable cause of #8 by setting the train to automatic mode if it was in automatic mode prior to loading/unloading
- Prevents loading/unloading while the train is in motion to prevent abuse now that an automatic train will no longer switch into manual mode and plow through three signal blocks and one or more other trains.